### PR TITLE
36-feat-card-transactions

### DIFF
--- a/internal/traderepublc/api/timeline/details/response.go
+++ b/internal/traderepublc/api/timeline/details/response.go
@@ -36,6 +36,7 @@ const (
 	OrderTypeTextsSale                      = "Verkauf"
 	OrderTypeTextsPurchase                  = "Kauf"
 	TrendNegative                           = "negative"
+	CardPaymentTransactionBeneficiary       = "Händler"
 )
 
 var ErrSectionDataTitleNotFound = errors.New("section data title not found")

--- a/internal/traderepublc/api/timeline/details/type.go
+++ b/internal/traderepublc/api/timeline/details/type.go
@@ -134,6 +134,6 @@ func WithdrawalDetector(eventType transactions.EventType, _ NormalizedResponse) 
 }
 
 func CardPaymentDetector(eventType transactions.EventType, response NormalizedResponse) bool {
-	// TODO(yann): incomplete. What about failed transactions / refunds?
+	// TODO: incomplete. What about failed transactions / refunds?
 	return eventType == transactions.EventTypeCardSuccessfulTransaction
 }

--- a/internal/traderepublc/api/timeline/details/type.go
+++ b/internal/traderepublc/api/timeline/details/type.go
@@ -49,6 +49,7 @@ func NewTypeResolver(logger *log.Logger) TypeResolver {
 			TypeRoundUpTransaction:        RoundUpDetector,
 			TypeSavebackTransaction:       SavebackDetector,
 			TypeInterestPayoutTransaction: InterestPayoutDetector,
+			TypeCardPaymentTransaction:    CardPaymentDetector,
 
 			// Detectors with the highest performance hit should be listed in the bottom.
 			TypePurchaseTransaction: PurchaseDetector,
@@ -130,4 +131,9 @@ func DividendPayoutDetector(eventType transactions.EventType, _ NormalizedRespon
 
 func WithdrawalDetector(eventType transactions.EventType, _ NormalizedResponse) bool {
 	return eventType == transactions.EventTypePaymentOutbound
+}
+
+func CardPaymentDetector(eventType transactions.EventType, response NormalizedResponse) bool {
+	// TODO(yann): incomplete. What about failed transactions / refunds?
+	return eventType == transactions.EventTypeCardSuccessfulTransaction
 }

--- a/internal/traderepublc/api/timeline/transactions/type.go
+++ b/internal/traderepublc/api/timeline/transactions/type.go
@@ -51,6 +51,7 @@ func NewEventTypeResolver(logger *log.Logger) EventTypeResolver {
 			EventTypeBenefitsSavebackExecution,
 			EventTypeBenefitsSpareChangeExecution,
 			EventTypeSSPCorporateActionInvoiceCash,
+			EventTypeCardSuccessfulTransaction,
 		},
 		logger: logger,
 	}

--- a/internal/traderepublc/portfolio/instrument/model_builder.go
+++ b/internal/traderepublc/portfolio/instrument/model_builder.go
@@ -56,6 +56,7 @@ func (b ModelBuilder) ExtractInstrumentName(response details.NormalizedResponse)
 		details.OverviewDataTitleAsset,
 		details.OverviewDataTitleUnderlyingAsset,
 		details.OverviewDataTitleSecurity,
+		details.CardPaymentTransactionBeneficiary,
 	)
 	if err != nil {
 		return "", fmt.Errorf("could not get overview section asset: %w", err)

--- a/internal/traderepublc/portfolio/transaction/factory.go
+++ b/internal/traderepublc/portfolio/transaction/factory.go
@@ -45,6 +45,8 @@ func (f CSVEntryFactory) Make(transaction Model) (filesystem.CSVEntry, error) {
 	case TypeDividendPayout:
 		profit = transaction.Total
 		credit = transaction.Total
+	case TypeCardPaymentTransaction:
+		debit = transaction.Total
 	default:
 		return filesystem.CSVEntry{}, fmt.Errorf(
 			"unsupported type '%s' received: %w",

--- a/internal/traderepublc/portfolio/transaction/model.go
+++ b/internal/traderepublc/portfolio/transaction/model.go
@@ -8,14 +8,15 @@ import (
 )
 
 const (
-	TypePurchase       = "Purchase"
-	TypeSale           = "Sale"
-	TypeDividendPayout = "Dividends"
-	TypeRoundUp        = "Round up"
-	TypeSaveback       = "Saveback"
-	TypeDeposit        = "Deposit"
-	TypeWithdrawal     = "Withdrawal"
-	TypeInterestPayout = "Interest payout"
+	TypePurchase               = "Purchase"
+	TypeSale                   = "Sale"
+	TypeDividendPayout         = "Dividends"
+	TypeRoundUp                = "Round up"
+	TypeSaveback               = "Saveback"
+	TypeDeposit                = "Deposit"
+	TypeWithdrawal             = "Withdrawal"
+	TypeInterestPayout         = "Interest payout"
+	TypeCardPaymentTransaction = "Card payment"
 )
 
 type Model struct {

--- a/internal/traderepublc/portfolio/transaction/model_builder.go
+++ b/internal/traderepublc/portfolio/transaction/model_builder.go
@@ -533,8 +533,6 @@ func NewPaymentTransactionBuilder(baseBuilder BaseModelBuilder) PaymentTransacti
 }
 
 func (b PaymentTransactionBuilder) ExtractTotalAmount() (float64, error) {
-	// example string: "Du hast 2,00\u00a0€ ausgegeben"
-	// TODO: as per given example: maybe unicode errors occur while parsing?
 	totalAmountStr, err := ParseNumericValueFromString(b.response.Header.Title)
 	if err != nil {
 		return 0, err

--- a/internal/traderepublc/portfolio/transaction/model_builder.go
+++ b/internal/traderepublc/portfolio/transaction/model_builder.go
@@ -82,9 +82,9 @@ func (f ModelBuilderFactory) Create(
 		return NewWithdrawBuilder(NewDepositBuilder(baseBuilder)), nil
 	case details.TypeInterestPayoutTransaction:
 		return NewInterestPayoutBuilder(baseBuilder), nil
-	case
-		details.TypeUnsupported,
-		details.TypeCardPaymentTransaction:
+	case details.TypeCardPaymentTransaction:
+		return NewPaymentTransactionBuilder(baseBuilder), nil
+	case details.TypeUnsupported:
 		return nil, ErrModelBuilderUnsupportedType
 	}
 
@@ -520,6 +520,69 @@ func (b InterestPayoutBuilder) Build() (Model, error) {
 
 	model.Instrument, _ = b.instrumentBuilder.Build(b.response)
 	model.Documents, _ = b.BuildDocuments(model)
+
+	return model, nil
+}
+
+type PaymentTransactionBuilder struct {
+	BaseModelBuilder
+}
+
+func NewPaymentTransactionBuilder(baseBuilder BaseModelBuilder) PaymentTransactionBuilder {
+	return PaymentTransactionBuilder{BaseModelBuilder: baseBuilder}
+}
+
+func (b PaymentTransactionBuilder) ExtractTotalAmount() (float64, error) {
+	// example string: "Du hast 2,00\u00a0€ ausgegeben"
+	// TODO: as per given example: maybe unicode errors occur while parsing?
+	totalAmountStr, err := ParseNumericValueFromString(b.response.Header.Title)
+	if err != nil {
+		return 0, err
+	}
+
+	total, err := ParseFloatWithComma(totalAmountStr, false)
+	if err != nil {
+		return total, err
+	}
+
+	return total, nil
+}
+
+func (b PaymentTransactionBuilder) Build() (Model, error) {
+	var err error
+
+	// data is mapped as follows:
+	// paid amount: -> model.Total
+	// beneficiary: -> model.Instrument.Name
+
+	model := Model{
+		UUID: b.response.ID,
+		Type: TypeCardPaymentTransaction,
+	}
+
+	model.Total, err = b.ExtractTotalAmount()
+	if err != nil {
+		return model, b.HandleErr(err)
+	}
+
+	model.Instrument, err = b.instrumentBuilder.Build(b.response)
+	if err != nil {
+		return model, b.HandleErr(err)
+	}
+
+	// TypeResolver executed in instance of instrumentBuilder can't detect if an isntrument name refers to a beneficiary.
+	// Thus it maps card payments to Other. We manually overwrite this here.
+	model.Instrument.Type = instrument.TypeCash
+
+	model.Status, err = b.ExtractStatus()
+	if err != nil {
+		return model, b.HandleErr(err)
+	}
+
+	model.Timestamp, err = b.ExtractTimestamp()
+	if err != nil {
+		return model, b.HandleErr(err)
+	}
 
 	return model, nil
 }


### PR DESCRIPTION
closes #36 

As of now the implementation writes Card payment information to the already generated CSV.

Polluted fields:
| field | value |
| --- | --- | 
| ID| generated as in other rows|
| Status| generated as in other rows |
| Timestamp| date of transaction|
| Type| Cash|
| Name| Beneficiary (name)|
| Debit| amount payed|


## whats missing for this PR to be closed (IMO)

- [ ] prevent log warnings for fields unique for card payment transactions
- [ ] tests
- [ ] map available IBAN letters to CSV (first 4 numbers are available)
- [ ] maybe append Readme
- [ ] validate detector (no data available for failed transactions from my side, marked as TODO in-code)

I hope I utilized the corresponding patterns correctly and sticked to your style. As it's my first time writing Go I'd be grateful if you comment if you see a problem with the used style&approaches.