### PR TITLE
Resolves #47

### DIFF
--- a/internal/traderepublc/api/timeline/details/normalizer.go
+++ b/internal/traderepublc/api/timeline/details/normalizer.go
@@ -62,7 +62,7 @@ func (n TransactionResponseNormalizer) Normalize(response Response) (NormalizedR
 
 	resp.Documents, err = n.SectionTypeDocuments(response)
 	if err != nil {
-		n.logger.Warnf("could not deserialize documents section: %v", err)
+		n.logger.Debugf("could not deserialize documents section: %v", err)
 	}
 
 	return resp, nil

--- a/internal/traderepublc/api/timeline/transactions/type.go
+++ b/internal/traderepublc/api/timeline/transactions/type.go
@@ -4,6 +4,7 @@ package transactions
 
 import (
 	"errors"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -67,5 +68,5 @@ func (e EventTypeResolver) Resolve(response ResponseItem) (EventType, error) {
 		return t, nil
 	}
 
-	return "", ErrEventTypeUnsupported
+	return "", fmt.Errorf("%w: %s", ErrEventTypeUnsupported, response.EventType)
 }

--- a/internal/traderepublc/portfolio/transaction/handler.go
+++ b/internal/traderepublc/portfolio/transaction/handler.go
@@ -71,6 +71,7 @@ func (h Handler) Handle() error {
 
 			continue
 		case errors.Is(err, transactions.ErrEventTypeUnsupported):
+			h.logger.Debug(err)
 			h.logger.WithFields(infoFields).Warn("Unsupported transaction skipped")
 			counter.Skipped().Add(1)
 


### PR DESCRIPTION
- Moved "could not deserialize documents section" message to debug

- Added additional debug message to see the type of unsupported transaction